### PR TITLE
Fix TODO / hats for 0.7

### DIFF
--- a/src/game/client/gameclient.h
+++ b/src/game/client/gameclient.h
@@ -488,7 +488,7 @@ public:
 	void OnConsoleInit() override;
 	void OnStateChange(int NewState, int OldState) override;
 	template<typename T>
-	void ApplySkin7InfoFromGameMsg(const T *pMsg, CClientData *pClient);
+	void ApplySkin7InfoFromGameMsg(const T *pMsg, int ClientID);
 	void *TranslateGameMsg(int *pMsgID, CUnpacker *pUnpacker);
 	void OnMessage(int MsgId, CUnpacker *pUnpacker, int Conn, bool Dummy) override;
 	void InvalidateSnapshot() override;

--- a/src/game/client/render.cpp
+++ b/src/game/client/render.cpp
@@ -432,33 +432,32 @@ void CRenderTools::RenderTee7(const CAnimState *pAnim, const CTeeRenderInfo *pIn
 				}
 				Graphics()->QuadsEnd();
 
-				// TODO: ddnet has own hats
 				// draw xmas hat
-				// if(!OutLine && pInfo->m_HatTexture.IsValid())
-				// {
-				// 	Graphics()->TextureSet(pInfo->m_HatTexture);
-				// 	Graphics()->QuadsBegin();
-				// 	Graphics()->QuadsSetRotation(pAnim->GetBody()->m_Angle*pi * 2);
-				// 	Graphics()->SetColor(1.0f, 1.0f, 1.0f, 1.0f);
-				// 	int Flag = Direction.x < 0.0f ? SPRITE_FLAG_FLIP_X : 0;
-				// 	switch(pInfo->m_HatSpriteIndex)
-				// 	{
-				// 	case 0:
-				// 		SelectSprite7(SPRITE_TEE_HATS_TOP1, Flag, 0, 0);
-				// 		break;
-				// 	case 1:
-				// 		SelectSprite7(SPRITE_TEE_HATS_TOP2, Flag, 0, 0);
-				// 		break;
-				// 	case 2:
-				// 		SelectSprite7(SPRITE_TEE_HATS_SIDE1, Flag, 0, 0);
-				// 		break;
-				// 	case 3:
-				// 		SelectSprite7(SPRITE_TEE_HATS_SIDE2, Flag, 0, 0);
-				// 	}
-				// 	Item = BodyItem;
-				// 	Graphics()->QuadsDraw(&Item, 1);
-				// 	Graphics()->QuadsEnd();
-				// }
+				if(!OutLine && pInfo->m_HatTexture.IsValid())
+				{
+					Graphics()->TextureSet(pInfo->m_HatTexture);
+					Graphics()->QuadsBegin();
+					Graphics()->QuadsSetRotation(pAnim->GetBody()->m_Angle * pi * 2);
+					Graphics()->SetColor(1.0f, 1.0f, 1.0f, 1.0f);
+					int Flag = Direction.x < 0.0f ? SPRITE_FLAG_FLIP_X : 0;
+					switch(pInfo->m_HatSpriteIndex)
+					{
+					case 0:
+						SelectSprite7(client_data7::SPRITE_TEE_HATS_TOP1, Flag, 0, 0);
+						break;
+					case 1:
+						SelectSprite7(client_data7::SPRITE_TEE_HATS_TOP2, Flag, 0, 0);
+						break;
+					case 2:
+						SelectSprite7(client_data7::SPRITE_TEE_HATS_SIDE1, Flag, 0, 0);
+						break;
+					case 3:
+						SelectSprite7(client_data7::SPRITE_TEE_HATS_SIDE2, Flag, 0, 0);
+					}
+					Item = BodyItem;
+					Graphics()->QuadsDraw(&Item, 1);
+					Graphics()->QuadsEnd();
+				}
 			}
 
 			// draw feet

--- a/src/game/client/render.h
+++ b/src/game/client/render.h
@@ -48,6 +48,13 @@ public:
 		m_GotAirJump = true;
 		m_TeeRenderFlags = 0;
 		m_FeetFlipped = false;
+
+		for(ColorRGBA &PartColor : m_aColors)
+		{
+			PartColor = ColorRGBA(1.0f, 1.0f, 1.0f, 1.0f);
+		}
+		m_HatSpriteIndex = 0;
+		m_BotColor = ColorRGBA(1.0f, 1.0f, 1.0f, 1.0f);
 	}
 
 	CSkin::SSkinTextures m_OriginalRenderSkin;

--- a/src/game/client/render.h
+++ b/src/game/client/render.h
@@ -68,7 +68,9 @@ public:
 	// 0.7
 	IGraphics::CTextureHandle m_aTextures[NUM_SKINPARTS];
 	ColorRGBA m_aColors[NUM_SKINPARTS];
+	IGraphics::CTextureHandle m_HatTexture;
 	IGraphics::CTextureHandle m_BotTexture;
+	int m_HatSpriteIndex;
 	ColorRGBA m_BotColor;
 };
 


### PR DESCRIPTION
This fixed hats for me with 0.7 skins system ON. See the screenshots at https://github.com/ddnet/ddnet/pull/7715

And hmm, as I messed up the clang-tidy and the commits https://github.com/ChillerDragon/ddnet/pull/3#issuecomment-1868574554 are not complete (in terms of "not changed in further commits and can be picked as is to the master") I think that it makes sense to **squash everything** again. Sorry.

It makes sense to keep individual commits as long as they simplify the process **for the reviewers** and/or allow later to do atomic cherry-pick/revert.