### PR TITLE
Move size inside `NetTwIntString` type, fix debug dump

### DIFF
--- a/datasrc/compile.py
+++ b/datasrc/compile.py
@@ -283,6 +283,7 @@ void CNetObjHandler::DebugDumpSnapshot(const CSnapshot *pSnap) const
 	lines += ['int CNetObjHandler::DumpObj(int Type, const void *pData, int Size) const']
 	lines += ['{']
 	lines += ["\tchar aRawData[512];"]
+	lines += ["\tchar aStr[128];"]
 	lines += ['\tswitch(Type)']
 	lines += ['\t{']
 

--- a/datasrc/network.py
+++ b/datasrc/network.py
@@ -221,19 +221,11 @@ Objects = [
 	]),
 
 	NetObject("ClientInfo", [
-		# 4*4 = 16 characters
-		NetArray(NetTwIntString("m_aName"), 4),
-
-		# 4*3 = 12 characters
-		NetArray(NetTwIntString("m_aClan"), 3),
-
+		NetTwIntString("m_aName", 16),
+		NetTwIntString("m_aClan", 12),
 		NetIntAny("m_Country"),
-
-		# 4*6 = 24 characters
-		NetArray(NetTwIntString("m_aSkin"), 6),
-
+		NetTwIntString("m_aSkin", 24),
 		NetIntRange("m_UseCustomColor", 0, 1),
-
 		NetIntAny("m_ColorBody"),
 		NetIntAny("m_ColorFeet"),
 	]),


### PR DESCRIPTION
The code for the debug dump of `NetTwIntString`s was not being emitted due to it being wrapped in a `NetArray`. It also did not compile because variables `aStr` and `aInts` were not defined.

The string size in `char`s is now passed as an argument to `NetTwIntString`, which is a specialization of `NetArray`, instead of wrapping the `NetTwIntString` in a `NetArray`.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
